### PR TITLE
Added dynamic import to fix deployment errors

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,18 @@
 "use client";
 
 // import ImgMap from "@/components/responsiveMap";
+import dynamic from "next/dynamic";
 
 export default function Home() {
 
+  const MyMap = dynamic(
+    () => import('@/components/responsiveMap'),
+    { ssr: false }
+  )
+
   return (
     <main className={`container bg-[url("../../public/assets/background.png")]`}>
-      {/* <ImgMap /> */}
+      <MyMap />
     </main>
   );
 }


### PR DESCRIPTION
**Faced an error on Vercel during deployment because the image-map-resizer library was using the Window API which was not available during Server side rendering. Fixed this error by using a dynamic import and setting SSR to False for the component being imported.**